### PR TITLE
Vejle Faktatjek: pipeline til faktatjek af byrådets lydoptagelser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Kopiér til .env og udfyld.
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Valgfrit — standardværdier vist:
+# VF_MODEL=claude-opus-4-8
+# VF_DB=data/vejle.db
+# VF_AUDIO_DIR=data/audio
+# VF_WHISPER_MODEL=large-v3        # eller sti til dansk-tunet CoRal-model
+# VF_HF_TOKEN=                     # Hugging Face token til pyannote diarization

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Python
+__pycache__/
+*.pyc
+.venv/
+*.egg-info/
+
+# Hemmeligheder
+.env
+
+# Genererede data
+data/*.db
+data/audio/
+
+# Build-artefakt (genereres med `build-site`; sample-versionen er committet)
+# web/leaderboard.json

--- a/README.md
+++ b/README.md
@@ -76,12 +76,29 @@ python -m vejle_faktatjek.cli factcheck --meeting 1
 python -m vejle_faktatjek.cli build-site
 ```
 
-## Politiker-roster
+## Politiker-roster og taler-ID
 
-Taler-identifikation kobler "Speaker 1/2/3" fra diarization til navngivne
-politikere. Udfyld `data/politicians.json` med byrådets medlemmer (navn + parti).
-Indtil hver politiker har et stemme-aftryk (`voiceprint`), markeres ukendte
-talere som `Ukendt` og kan rettes manuelt i databasen.
+Udfyld `data/politicians.json` med byrådets medlemmer (navn + parti).
+
+Taler-identifikation kobler diarization-klynger ("SPEAKER_00") til navngivne
+politikere på to måder:
+
+1. **Automatisk via stemme-aftryk** (anbefalet). Enrollér hver politiker én gang
+   fra et stykke lyd hvor man ved hvem der taler:
+
+   ```bash
+   python -m vejle_faktatjek.cli enroll \
+       --name "Jens Ejner Christensen" \
+       --audio data/audio/eksempel.wav --spans "12.0-95.0"
+   ```
+
+   Derefter matcher pipelinen automatisk hvert nyt mødes talere mod aftrykkene
+   (cosine-lighed over en tærskel). Kør `identify --meeting N` separat, eller
+   lad `run` gøre det automatisk.
+
+2. **Manuelt** hvis et aftryk mangler: giv `run --label-map '{"SPEAKER_00": "Navn"}'`,
+   eller ret `politician_id` på segmenterne i databasen. Ukendte talere forbliver
+   `Ukendt`.
 
 ## Vurderingskategorier
 
@@ -97,7 +114,8 @@ så en der siger lidt ikke fremstår kunstigt pålidelig.
 | `config.py` | Konfiguration (API-nøgle, model, stier) fra miljøvariabler |
 | `fetch.py` | Hent lyd/stream fra vejle.dk / Kommune-TV → 16 kHz WAV |
 | `transcribe.py` | Dansk ASR + speaker diarization → segmenter |
-| `speakers.py` | Match diarization-labels til navngivne politikere |
+| `voiceprints.py` | Stemme-aftryk: automatisk match af diarization-klynger → politikere |
+| `speakers.py` | Manuel match af diarization-labels til navngivne politikere |
 | `claims.py` | Udtræk efterprøvbare påstande (Claude, struktureret output) |
 | `factcheck.py` | Evidensbaseret dom pr. påstand (Claude + `web_search`) |
 | `store.py` | SQLite-lager + datamodel |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,114 @@
-# hello-world
-Hello world
-not much to see here...
+# Vejle Faktatjek
+
+Pipeline der henter lydoptagelser fra Vejle Byråds møder, transskriberer dem
+med taler-identifikation, udtrækker efterprøvbare påstande, faktatjekker dem med
+Claude + websøgning, og bygger et leaderboard over politikernes og partiernes
+pålidelighed.
+
+> Datagrundlaget (lydoptagelser, dagsordener, referater) er offentligt tilgængeligt
+> på [vejle.dk](https://www.vejle.dk/politik/politik-og-byraad/moeder-i-byraad-og-udvalg/lydoptagelser-fra-byraadsmoeder/)
+> og via [Kommune-TV](https://kommune-tv.dk/).
+
+## Arkitektur
+
+```
+  Kommune-TV / vejle.dk lyd-URL
+            │  (fetch.py)
+            ▼
+   Lydfil (16 kHz mono WAV)
+            │  (transcribe.py — faster-whisper + diarization)
+            ▼
+   Segmenter: {taler, start, slut, tekst}
+            │  (speakers.py — match Speaker-N → navngiven politiker)
+            ▼
+   Påstande   (claims.py — Claude, struktureret output)
+            │
+            ▼
+   Domme      (factcheck.py — Claude + web_search, evidensbaseret)
+            │  (store.py — SQLite)
+            ▼
+   leaderboard.json  (leaderboard.py / scripts/build_site.py)
+            │
+            ▼
+   Statisk side (web/index.html)
+```
+
+Pipelinen kører som batch efter hvert møde. Hvert trin er et selvstændigt modul
+med et rent interface, så et live-overlay senere kan genbruge `transcribe` +
+`claims` + `factcheck` oven på en streaming-kilde.
+
+## Hurtig start
+
+### 1. Installér
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env   # udfyld ANTHROPIC_API_KEY
+```
+
+`faster-whisper` og `whisperx` er valgfrie tunge afhængigheder (kun nødvendige
+for selve transskriptionen). Resten af pipelinen og leaderboardet kører uden dem.
+
+### 2. Se leaderboardet med det samme (sample-data)
+
+```bash
+python -m vejle_faktatjek.cli seed-demo      # indlæser data/sample i en lokal DB
+python -m vejle_faktatjek.cli build-site     # genererer web/leaderboard.json
+python -m http.server -d web 8000            # åbn http://localhost:8000
+```
+
+### 3. Kør et rigtigt møde gennem pipelinen
+
+```bash
+# Hele kæden fra en lyd-URL:
+python -m vejle_faktatjek.cli run \
+    --url "https://…/byraadsmoede-2026-06-15.mp3" \
+    --date 2026-06-15 --title "Byrådsmøde juni 2026"
+
+# Eller ét trin ad gangen:
+python -m vejle_faktatjek.cli fetch --url "…" --date 2026-06-15
+python -m vejle_faktatjek.cli transcribe --meeting 1
+python -m vejle_faktatjek.cli extract-claims --meeting 1
+python -m vejle_faktatjek.cli factcheck --meeting 1
+python -m vejle_faktatjek.cli build-site
+```
+
+## Politiker-roster
+
+Taler-identifikation kobler "Speaker 1/2/3" fra diarization til navngivne
+politikere. Udfyld `data/politicians.json` med byrådets medlemmer (navn + parti).
+Indtil hver politiker har et stemme-aftryk (`voiceprint`), markeres ukendte
+talere som `Ukendt` og kan rettes manuelt i databasen.
+
+## Vurderingskategorier
+
+Hver påstand dømmes som én af: `Korrekt`, `Delvist korrekt`, `Misvisende`,
+`Forkert`, `Ikke verificerbar`. Pålidelighedsscoren pr. politiker/parti bygger
+**kun** på de verificerbare påstande, og antallet vises altid ved siden af scoren
+så en der siger lidt ikke fremstår kunstigt pålidelig.
+
+## Moduloversigt
+
+| Modul | Ansvar |
+|-------|--------|
+| `config.py` | Konfiguration (API-nøgle, model, stier) fra miljøvariabler |
+| `fetch.py` | Hent lyd/stream fra vejle.dk / Kommune-TV → 16 kHz WAV |
+| `transcribe.py` | Dansk ASR + speaker diarization → segmenter |
+| `speakers.py` | Match diarization-labels til navngivne politikere |
+| `claims.py` | Udtræk efterprøvbare påstande (Claude, struktureret output) |
+| `factcheck.py` | Evidensbaseret dom pr. påstand (Claude + `web_search`) |
+| `store.py` | SQLite-lager + datamodel |
+| `leaderboard.py` | Aggregér domme til pålidelighedsscorer |
+| `pipeline.py` | Orkestrér hele kæden |
+| `cli.py` | Kommandolinje-interface |
+
+## Status / begrænsninger
+
+- Faktatjek er evidensbaseret (Claude får websøgeresultater og dømmer ud fra dem,
+  ikke fra hukommelsen) — men kvaliteten afhænger af kilderne. Hold et menneske
+  på godkendelse før noget publiceres offentligt.
+- ASR på dansk er bedst med en dansk-tunet model (se `transcribe.py`).
+- Stemme-baseret taler-ID er ikke implementeret endnu (kræver indtalte profiler);
+  i mellemtiden bruges referatets talerækkefølge som hint + manuel kvalitetssikring.
+```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Vejle Faktatjek
 
-Pipeline der henter lydoptagelser fra Vejle Byråds møder, transskriberer dem
-med taler-identifikation, udtrækker efterprøvbare påstande, faktatjekker dem med
-Claude + websøgning, og bygger et leaderboard over politikernes og partiernes
-pålidelighed.
+Pipeline der henter **lydoptagelser fra Vejle Byråds tidligere møder**,
+transskriberer dem med taler-identifikation, udtrækker efterprøvbare påstande,
+faktatjekker dem med Claude + websøgning, og bygger et leaderboard over
+politikernes og partiernes pålidelighed.
 
-> Datagrundlaget (lydoptagelser, dagsordener, referater) er offentligt tilgængeligt
-> på [vejle.dk](https://www.vejle.dk/politik/politik-og-byraad/moeder-i-byraad-og-udvalg/lydoptagelser-fra-byraadsmoeder/)
-> og via [Kommune-TV](https://kommune-tv.dk/).
+> Vejle Kommune sender ikke live-TV fra byrådet, men publicerer lydoptagelser
+> fra afholdte møder på
+> [vejle.dk](https://www.vejle.dk/politik/politik-og-byraad/moeder-i-byraad-og-udvalg/lydoptagelser-fra-byraadsmoeder/).
+> Pipelinen er derfor rent batch-baseret: den behandler én optagelse ad gangen,
+> efter mødet er holdt.
 
 ## Arkitektur
 
 ```
-  Kommune-TV / vejle.dk lyd-URL
+  vejle.dk lyd-URL (afholdt møde)
             │  (fetch.py)
             ▼
    Lydfil (16 kHz mono WAV)

--- a/data/politicians.json
+++ b/data/politicians.json
@@ -1,0 +1,9 @@
+[
+  {"name": "Jens Ejner Christensen", "party": "Venstre"},
+  {"name": "Søren Peschardt", "party": "Socialdemokratiet"},
+  {"name": "Morten Kristensen", "party": "SF"},
+  {"name": "Torben Elsig-Pedersen", "party": "Radikale Venstre"},
+  {"name": "Dan Arnløv Jørgensen", "party": "Det Konservative Folkeparti"},
+  {"name": "Holger Gorm Petersen", "party": "Danmarksdemokraterne"},
+  {"name": "Gerda Haastrup Jørgensen", "party": "Enhedslisten"}
+]

--- a/data/sample/meetings.json
+++ b/data/sample/meetings.json
@@ -1,0 +1,45 @@
+[
+  {
+    "date": "2026-03-25",
+    "title": "Byrådsmøde marts 2026 (sample-data)",
+    "source_url": "https://www.vejle.dk/politik/politik-og-byraad/moeder-i-byraad-og-udvalg/lydoptagelser-fra-byraadsmoeder/",
+    "segments": [
+      {"speaker": "SPEAKER_00", "politician": "Jens Ejner Christensen", "start": 120.0, "end": 168.0,
+       "text": "Vejle Kommune har over 120.000 indbyggere, og vi er den hurtigst voksende kommune i Trekantområdet."},
+      {"speaker": "SPEAKER_01", "politician": "Søren Peschardt", "start": 305.0, "end": 360.0,
+       "text": "Kommunens kassebeholdning er faldet med næsten en halv milliard kroner på to år, og det er dybt bekymrende."}
+    ],
+    "claims": [
+      {"text": "Vejle Kommune har over 120.000 indbyggere.", "category": "andet", "ts": 120.0,
+       "politician": "Jens Ejner Christensen",
+       "verdict": {"rating": "Korrekt", "confidence": 0.92,
+         "explanation": "Danmarks Statistik opgør Vejle Kommunes folketal til over 120.000. Påstanden stemmer med de officielle tal.",
+         "sources": [{"title": "Danmarks Statistik — Folketal", "url": "https://www.statistikbanken.dk/folk1a"}]}},
+      {"text": "Vejle er den hurtigst voksende kommune i Trekantområdet.", "category": "andet", "ts": 150.0,
+       "politician": "Jens Ejner Christensen",
+       "verdict": {"rating": "Delvist korrekt", "confidence": 0.6,
+         "explanation": "Vejle er blandt de hurtigst voksende kommuner i området, men den præcise placering varierer fra år til år og afhænger af opgørelsesmetode.",
+         "sources": [{"title": "Danmarks Statistik — Befolkningsfremskrivning", "url": "https://www.dst.dk/da/Statistik/emner/befolkning-og-valg"}]}},
+      {"text": "Kommunens kassebeholdning er faldet med næsten en halv milliard kroner på to år.", "category": "økonomi", "ts": 305.0,
+       "politician": "Søren Peschardt",
+       "verdict": {"rating": "Misvisende", "confidence": 0.55,
+         "explanation": "Kassebeholdningen er faldet, men ikke i den størrelsesorden ifølge kommunens regnskaber; tallet mangler kontekst om planlagte anlægsinvesteringer.",
+         "sources": [{"title": "Vejle Kommune — Årsregnskab", "url": "https://www.vejle.dk/om-kommunen/oekonomi/"}]}},
+      {"text": "Ledigheden i Vejle Kommune er lavere end landsgennemsnittet.", "category": "beskæftigelse", "ts": 420.0,
+       "politician": "Morten Kristensen",
+       "verdict": {"rating": "Korrekt", "confidence": 0.8,
+         "explanation": "Officielle ledighedstal viser en bruttoledighed i Vejle under landsgennemsnittet i den seneste opgørelse.",
+         "sources": [{"title": "Jobindsats / Danmarks Statistik", "url": "https://www.jobindsats.dk/"}]}},
+      {"text": "Kommunen plantede én million træer sidste år.", "category": "klima", "ts": 540.0,
+       "politician": "Torben Elsig-Pedersen",
+       "verdict": {"rating": "Ikke verificerbar", "confidence": 0.4,
+         "explanation": "Der findes ingen offentligt tilgængelig opgørelse der be- eller afkræfter det præcise antal plantede træer.",
+         "sources": []}},
+      {"text": "Vejle Kommune har ikke hævet dækningsafgiften de seneste fem år.", "category": "økonomi", "ts": 660.0,
+       "politician": "Dan Arnløv Jørgensen",
+       "verdict": {"rating": "Forkert", "confidence": 0.7,
+         "explanation": "Budgetmaterialet viser en justering af dækningsafgiften inden for perioden, hvilket modsiger påstanden.",
+         "sources": [{"title": "Vejle Kommune — Budget", "url": "https://www.vejle.dk/om-kommunen/oekonomi/"}]}}
+    ]
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ yt-dlp>=2024.0
 # faster-whisper>=1.0
 # whisperx>=3.1            # ord-præcise tidsstempler + diarization
 # torch>=2.0
+
+# Stemme-aftryk / taler-ID (voiceprints.py) — valgfri, tunge afhængigheder:
+# speechbrain>=1.0         # ECAPA-TDNN embeddings
+# torchaudio>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+# Kerne — krævet
+anthropic>=0.92.0
+pydantic>=2.0
+
+# Lydhentning (fetch.py) — yt-dlp kan håndtere HLS-streams og direkte filer.
+# ffmpeg skal være installeret på systemet (ikke en pip-pakke).
+yt-dlp>=2024.0
+
+# Transskription (transcribe.py) — valgfri, tunge afhængigheder.
+# Afkommentér når du vil køre rigtig ASR:
+# faster-whisper>=1.0
+# whisperx>=3.1            # ord-præcise tidsstempler + diarization
+# torch>=2.0

--- a/src/vejle_faktatjek/__init__.py
+++ b/src/vejle_faktatjek/__init__.py
@@ -1,0 +1,3 @@
+"""Vejle Faktatjek — pipeline til faktatjek af Vejle Byråds lydoptagelser."""
+
+__version__ = "0.1.0"

--- a/src/vejle_faktatjek/claims.py
+++ b/src/vejle_faktatjek/claims.py
@@ -1,0 +1,59 @@
+"""Udtræk efterprøvbare påstande fra transskriberede taleture med Claude.
+
+Adskiller faktuelle, efterprøvbare påstande (kan tjekkes mod kilder) fra
+holdninger, forhandling og procedure — kun de første skal faktatjekkes.
+
+Bruger structured outputs (``messages.parse``) så outputtet er valideret JSON.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import anthropic
+from pydantic import BaseModel, Field
+
+from .config import CONFIG
+
+CATEGORIES = ["økonomi", "klima", "social", "infrastruktur", "beskæftigelse", "andet"]
+
+_SYSTEM = """Du analyserer transskriberet tale fra et dansk byrådsmøde i Vejle Kommune.
+Din opgave er at finde FAKTUELLE, EFTERPRØVBARE påstande — udsagn der kan
+afgøres som sande eller falske ved opslag i kilder (statistik, budgetter,
+regnskaber, referater, officielle data).
+
+Medtag KUN efterprøvbare påstande. Spring over:
+- holdninger og værdiudsagn ("det er en dårlig idé")
+- hensigtserklæringer og forslag om fremtiden
+- spørgsmål, procedure og høflighedsfraser
+
+Skriv hver påstand som en kort, selvstændig, faktatjekbar sætning på dansk.
+Bevar tal og navne præcist som de blev sagt."""
+
+
+class Claim(BaseModel):
+    text: str = Field(description="Selvstændig, efterprøvbar påstand på dansk.")
+    category: str = Field(description=f"Én af: {', '.join(CATEGORIES)}")
+
+
+class ClaimList(BaseModel):
+    claims: list[Claim]
+
+
+def extract_claims(turn_text: str, client: Optional[anthropic.Anthropic] = None) -> list[Claim]:
+    """Udtræk efterprøvbare påstande fra én taletur (kan være tom)."""
+    if not turn_text.strip():
+        return []
+    client = client or anthropic.Anthropic(api_key=CONFIG.require_api_key())
+
+    response = client.messages.parse(
+        model=CONFIG.model,
+        max_tokens=4000,
+        system=_SYSTEM,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "medium"},
+        messages=[{"role": "user", "content": f"Taletur:\n\n{turn_text}"}],
+        output_format=ClaimList,
+    )
+    parsed = response.parsed_output
+    return parsed.claims if parsed else []

--- a/src/vejle_faktatjek/cli.py
+++ b/src/vejle_faktatjek/cli.py
@@ -1,0 +1,132 @@
+"""Kommandolinje-interface for Vejle Faktatjek."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .config import CONFIG
+from .store import Store
+
+
+def _store() -> Store:
+    return Store(CONFIG.db_path)
+
+
+def cmd_seed_demo(args) -> None:
+    from .seed import seed_demo
+    store = _store()
+    stats = seed_demo(store)
+    print(f"Indlæst sample-data: {stats}")
+    store.close()
+
+
+def cmd_build_site(args) -> None:
+    from .pipeline import step_build_site
+    store = _store()
+    out = step_build_site(store)
+    print(f"Skrev leaderboard til {out}")
+    store.close()
+
+
+def cmd_fetch(args) -> None:
+    from .pipeline import load_roster, step_fetch
+    store = _store()
+    load_roster(store)
+    meeting_id = args.meeting or store.create_meeting(args.date, args.title or args.date, args.url)
+    wav = step_fetch(store, meeting_id, args.url)
+    print(f"Møde {meeting_id}: hentede lyd til {wav}")
+    store.close()
+
+
+def cmd_transcribe(args) -> None:
+    from .pipeline import step_transcribe
+    store = _store()
+    n = step_transcribe(store, args.meeting)
+    print(f"Møde {args.meeting}: {n} segmenter transskriberet")
+    store.close()
+
+
+def cmd_extract_claims(args) -> None:
+    from .pipeline import step_extract_claims
+    store = _store()
+    n = step_extract_claims(store, args.meeting)
+    print(f"Møde {args.meeting}: {n} påstande udtrukket")
+    store.close()
+
+
+def cmd_factcheck(args) -> None:
+    from .pipeline import step_factcheck
+    store = _store()
+    n = step_factcheck(store, args.meeting)
+    print(f"Møde {args.meeting}: {n} påstande faktatjekket")
+    store.close()
+
+
+def cmd_run(args) -> None:
+    from .pipeline import run_all
+    store = _store()
+    label_map = json.loads(args.label_map) if args.label_map else None
+    meeting_id = run_all(store, args.url, args.date, args.title or args.date, label_map)
+    print(f"Færdig. Møde-id {meeting_id}.")
+    store.close()
+
+
+def cmd_speakers(args) -> None:
+    from .speakers import speaker_label_summary
+    store = _store()
+    summary = speaker_label_summary(store, args.meeting)
+    for label, count in sorted(summary.items(), key=lambda x: -x[1]):
+        print(f"{label}: {count} segmenter")
+    store.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="vejle_faktatjek", description="Faktatjek af Vejle Byråds lydoptagelser")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("seed-demo", help="Indlæs sample-data i databasen").set_defaults(func=cmd_seed_demo)
+    sub.add_parser("build-site", help="Generér web/leaderboard.json").set_defaults(func=cmd_build_site)
+
+    f = sub.add_parser("fetch", help="Hent lydoptagelse")
+    f.add_argument("--url", required=True)
+    f.add_argument("--date", required=True)
+    f.add_argument("--title", default="")
+    f.add_argument("--meeting", type=int)
+    f.set_defaults(func=cmd_fetch)
+
+    t = sub.add_parser("transcribe", help="Transskribér et møde")
+    t.add_argument("--meeting", type=int, required=True)
+    t.set_defaults(func=cmd_transcribe)
+
+    e = sub.add_parser("extract-claims", help="Udtræk påstande")
+    e.add_argument("--meeting", type=int, required=True)
+    e.set_defaults(func=cmd_extract_claims)
+
+    c = sub.add_parser("factcheck", help="Faktatjek påstande")
+    c.add_argument("--meeting", type=int, required=True)
+    c.set_defaults(func=cmd_factcheck)
+
+    s = sub.add_parser("speakers", help="Vis speaker-labels for et møde")
+    s.add_argument("--meeting", type=int, required=True)
+    s.set_defaults(func=cmd_speakers)
+
+    r = sub.add_parser("run", help="Kør hele kæden for et nyt møde")
+    r.add_argument("--url", required=True)
+    r.add_argument("--date", required=True)
+    r.add_argument("--title", default="")
+    r.add_argument("--label-map", help='JSON, fx \'{"SPEAKER_00": "Jens Ejner Christensen"}\'')
+    r.set_defaults(func=cmd_run)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vejle_faktatjek/cli.py
+++ b/src/vejle_faktatjek/cli.py
@@ -73,6 +73,36 @@ def cmd_run(args) -> None:
     store.close()
 
 
+def _parse_spans(text: str | None):
+    if not text:
+        return None
+    spans = []
+    for part in text.split(","):
+        start, _, end = part.partition("-")
+        spans.append((float(start), float(end)))
+    return spans
+
+
+def cmd_enroll(args) -> None:
+    from .pipeline import load_roster
+    from .voiceprints import enroll_politician
+    store = _store()
+    load_roster(store)
+    dim = enroll_politician(store, args.name, args.audio, _parse_spans(args.spans))
+    print(f"Enrollerede stemme-aftryk for {args.name!r} (dim {dim}).")
+    store.close()
+
+
+def cmd_identify(args) -> None:
+    from .pipeline import step_identify_speakers
+    store = _store()
+    n, mapping = step_identify_speakers(store, args.meeting, args.threshold)
+    print(f"Møde {args.meeting}: tildelte {n} segmenter via stemme-aftryk.")
+    for label, name in sorted(mapping.items()):
+        print(f"  {label} → {name}")
+    store.close()
+
+
 def cmd_speakers(args) -> None:
     from .speakers import speaker_label_summary
     store = _store()
@@ -111,6 +141,17 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("speakers", help="Vis speaker-labels for et møde")
     s.add_argument("--meeting", type=int, required=True)
     s.set_defaults(func=cmd_speakers)
+
+    en = sub.add_parser("enroll", help="Gem et stemme-aftryk for en politiker")
+    en.add_argument("--name", required=True)
+    en.add_argument("--audio", required=True, help="Sti til lydfil med politikerens stemme")
+    en.add_argument("--spans", help='Valgfri udsnit i sek., fx "12.0-45.0,90-120"')
+    en.set_defaults(func=cmd_enroll)
+
+    idn = sub.add_parser("identify", help="Tildel talere via stemme-aftryk")
+    idn.add_argument("--meeting", type=int, required=True)
+    idn.add_argument("--threshold", type=float, default=0.5)
+    idn.set_defaults(func=cmd_identify)
 
     r = sub.add_parser("run", help="Kør hele kæden for et nyt møde")
     r.add_argument("--url", required=True)

--- a/src/vejle_faktatjek/config.py
+++ b/src/vejle_faktatjek/config.py
@@ -1,0 +1,47 @@
+"""Konfiguration læst fra miljøvariabler (og evt. en .env-fil)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+# Letvægts .env-indlæsning uden ekstra afhængighed.
+def _load_dotenv(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+_load_dotenv(Path(".env"))
+
+# Repo-rod (to niveauer op fra denne fil: src/vejle_faktatjek/config.py).
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class Config:
+    anthropic_api_key: str = os.environ.get("ANTHROPIC_API_KEY", "")
+    model: str = os.environ.get("VF_MODEL", "claude-opus-4-8")
+    db_path: Path = ROOT / os.environ.get("VF_DB", "data/vejle.db")
+    audio_dir: Path = ROOT / os.environ.get("VF_AUDIO_DIR", "data/audio")
+    whisper_model: str = os.environ.get("VF_WHISPER_MODEL", "large-v3")
+    hf_token: str = os.environ.get("VF_HF_TOKEN", "")
+    politicians_path: Path = ROOT / "data/politicians.json"
+    sample_dir: Path = ROOT / "data/sample"
+    site_data_path: Path = ROOT / "web/leaderboard.json"
+
+    def require_api_key(self) -> str:
+        if not self.anthropic_api_key:
+            raise RuntimeError(
+                "ANTHROPIC_API_KEY mangler. Sæt den i .env eller miljøet."
+            )
+        return self.anthropic_api_key
+
+
+CONFIG = Config()

--- a/src/vejle_faktatjek/factcheck.py
+++ b/src/vejle_faktatjek/factcheck.py
@@ -1,0 +1,117 @@
+"""Evidensbaseret faktatjek af en enkelt påstand med Claude.
+
+To trin, så domme bygger på fremfundet evidens — ikke på modellens hukommelse:
+
+  1. RESEARCH: Claude bruger det serverside web_search-værktøj til at finde
+     relevante kilder (helst danske: Danmarks Statistik, kommunens budgetter/
+     regnskaber, officielle registre, referater).
+  2. DOM: en separat, struktureret kald dømmer påstanden ud fra fundene og
+     returnerer en kategori + forklaring + kildehenvisninger.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import anthropic
+from pydantic import BaseModel, Field
+
+from .config import CONFIG
+
+RATINGS = ["Korrekt", "Delvist korrekt", "Misvisende", "Forkert", "Ikke verificerbar"]
+
+_RESEARCH_SYSTEM = """Du er faktatjekker. Du får én påstand fra et byrådsmøde i
+Vejle Kommune. Brug web_search til at finde pålidelig, helst dansk og officiel,
+evidens der kan be- eller afkræfte påstanden (Danmarks Statistik, kommunens
+budgetter og regnskaber, regionens data, officielle registre, mødereferater,
+anerkendte medier). Søg konkret og målrettet. Skriv til sidst et kort,
+nøgternt notat med de relevante fund og angiv URL'er. Konkludér ikke selv —
+referér kun evidensen."""
+
+_JUDGE_SYSTEM = f"""Du er faktatjekker og dømmer en påstand fra et byrådsmøde
+UDELUKKENDE ud fra den fremlagte evidens. Brug aldrig din egen hukommelse.
+
+Vælg én vurdering:
+- "Korrekt": evidensen understøtter påstanden klart.
+- "Delvist korrekt": rigtig i hovedtræk, men upræcis eller mangler forbehold.
+- "Misvisende": teknisk korrekte tal brugt vildledende, eller mangler vigtig kontekst.
+- "Forkert": evidensen modsiger påstanden.
+- "Ikke verificerbar": evidensen er utilstrækkelig til at dømme.
+
+Vær konservativ: vælg "Ikke verificerbar" hvis evidensen ikke er klar.
+confidence er 0-1. Skriv forklaringen kort og neutralt på dansk, og henvis til
+de konkrete kilder. Tilgængelige vurderinger: {', '.join(RATINGS)}."""
+
+
+class Source(BaseModel):
+    title: str = ""
+    url: str = ""
+
+
+class Verdict(BaseModel):
+    rating: str = Field(description=f"Én af: {', '.join(RATINGS)}")
+    confidence: float = Field(ge=0.0, le=1.0)
+    explanation: str
+    sources: list[Source] = []
+
+
+def _research(claim_text: str, client: anthropic.Anthropic) -> str:
+    """Kør web_search og returnér modellens evidensnotat som tekst."""
+    messages = [{"role": "user", "content": f"Påstand der skal undersøges:\n{claim_text}"}]
+    tools = [{
+        "type": "web_search_20260209",
+        "name": "web_search",
+        "max_uses": 6,
+    }]
+    # Serverside-værktøjsløkke: gentag ved pause_turn til modellen er færdig.
+    for _ in range(6):
+        resp = client.messages.create(
+            model=CONFIG.model,
+            max_tokens=4000,
+            system=_RESEARCH_SYSTEM,
+            thinking={"type": "adaptive"},
+            messages=messages,
+            tools=tools,
+        )
+        if resp.stop_reason == "pause_turn":
+            messages.append({"role": "assistant", "content": resp.content})
+            continue
+        text = "\n".join(b.text for b in resp.content if b.type == "text")
+        return text.strip()
+    return ""
+
+
+def _judge(claim_text: str, evidence: str, client: anthropic.Anthropic) -> Optional[Verdict]:
+    if not evidence:
+        return Verdict(
+            rating="Ikke verificerbar",
+            confidence=0.3,
+            explanation="Ingen evidens fundet ved websøgning.",
+            sources=[],
+        )
+    response = client.messages.parse(
+        model=CONFIG.model,
+        max_tokens=2000,
+        system=_JUDGE_SYSTEM,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "high"},
+        messages=[{
+            "role": "user",
+            "content": f"Påstand:\n{claim_text}\n\nFremfundet evidens:\n{evidence}",
+        }],
+        output_format=Verdict,
+    )
+    return response.parsed_output
+
+
+def factcheck(claim_text: str, client: Optional[anthropic.Anthropic] = None) -> Verdict:
+    """Faktatjek én påstand. Returnerer en valideret Verdict."""
+    client = client or anthropic.Anthropic(api_key=CONFIG.require_api_key())
+    evidence = _research(claim_text, client)
+    verdict = _judge(claim_text, evidence, client)
+    if verdict is None:
+        verdict = Verdict(rating="Ikke verificerbar", confidence=0.0,
+                          explanation="Kunne ikke danne en struktureret dom.", sources=[])
+    if verdict.rating not in RATINGS:
+        verdict.rating = "Ikke verificerbar"
+    return verdict

--- a/src/vejle_faktatjek/fetch.py
+++ b/src/vejle_faktatjek/fetch.py
@@ -1,0 +1,53 @@
+"""Hent lydoptagelse fra et tidligere Vejle Byråds-møde og normalisér til WAV.
+
+Vejle Kommune publicerer lydoptagelser fra byrådsmøder (ikke video/live) på
+vejle.dk. Find den direkte lyd-URL (typisk en .mp3) ved at inspicere
+afspillerens netværkskald, og giv den til ``download_audio``.
+
+Kræver ``yt-dlp`` (håndterer både direkte filer og HLS) og ``ffmpeg`` på PATH
+til at konvertere til 16 kHz mono WAV, som ASR-modeller forventer.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _have(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def download_audio(url: str, dest_dir: Path, name: str) -> Path:
+    """Hent ``url`` og returnér stien til en 16 kHz mono WAV.
+
+    ``name`` bruges som filnavn (uden endelse), fx mødedatoen.
+    """
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    raw = dest_dir / f"{name}.download"
+    wav = dest_dir / f"{name}.wav"
+
+    if not _have("ffmpeg"):
+        raise RuntimeError("ffmpeg er ikke installeret (kræves for WAV-konvertering).")
+
+    if _have("yt-dlp"):
+        # yt-dlp henter robust både direkte mediefiler og HLS-streams.
+        subprocess.run(
+            ["yt-dlp", "-f", "bestaudio/best", "-o", str(raw), url],
+            check=True,
+        )
+        src = raw
+    else:
+        # Fallback: lad ffmpeg hente direkte (virker for almindelige http(s)-filer).
+        src = url
+
+    # Konvertér til 16 kHz mono WAV.
+    subprocess.run(
+        ["ffmpeg", "-y", "-i", str(src), "-ac", "1", "-ar", "16000", str(wav)],
+        check=True,
+    )
+    if raw.exists():
+        raw.unlink()
+    return wav

--- a/src/vejle_faktatjek/leaderboard.py
+++ b/src/vejle_faktatjek/leaderboard.py
@@ -1,0 +1,93 @@
+"""Aggregér domme til pålidelighedsscorer pr. politiker og parti.
+
+Scoren bygger KUN på verificerbare domme (Korrekt / Delvist korrekt /
+Misvisende / Forkert). "Ikke verificerbar" tælles separat og påvirker ikke
+scoren. Antal påstande vises altid ved siden af scoren, så en politiker der
+siger lidt ikke fremstår kunstigt pålidelig.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .store import RATING_WEIGHT, VERIFIABLE_RATINGS, Store
+
+
+@dataclass
+class Tally:
+    name: str
+    party: str = ""
+    counts: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    weighted_sum: float = 0.0
+    verifiable: int = 0
+
+    def add(self, rating: str) -> None:
+        self.counts[rating] += 1
+        if rating in VERIFIABLE_RATINGS:
+            self.verifiable += 1
+            self.weighted_sum += RATING_WEIGHT[rating]
+
+    @property
+    def score(self) -> Optional[float]:
+        if self.verifiable == 0:
+            return None
+        return round(100 * self.weighted_sum / self.verifiable, 1)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "party": self.party,
+            "score": self.score,
+            "verifiable": self.verifiable,
+            "total": sum(self.counts.values()),
+            "breakdown": dict(self.counts),
+        }
+
+
+def build_leaderboard(store: Store) -> dict:
+    """Byg leaderboard-strukturen til frontend (politikere, partier, påstande)."""
+    rows = store.verdict_rows()
+
+    politicians: dict[str, Tally] = {}
+    parties: dict[str, Tally] = {}
+    claims_out: list[dict] = []
+
+    for r in rows:
+        name = r["politician"] or "Ukendt"
+        party = r["party"] or "Ukendt"
+        rating = r["rating"]
+
+        politicians.setdefault(name, Tally(name=name, party=party)).add(rating)
+        parties.setdefault(party, Tally(name=party, party=party)).add(rating)
+
+        try:
+            sources = json.loads(r["sources"] or "[]")
+        except (ValueError, TypeError):
+            sources = []
+        claims_out.append({
+            "claim": r["claim_text"],
+            "category": r["category"],
+            "politician": name,
+            "party": party,
+            "rating": rating,
+            "confidence": r["confidence"],
+            "explanation": r["explanation"],
+            "sources": sources,
+            "meeting": {"date": r["date"], "title": r["title"]},
+        })
+
+    def ranked(d: dict[str, Tally]) -> list[dict]:
+        items = [t.to_dict() for t in d.values()]
+        # Sortér: dem med en score først (højest øverst), dem uden til sidst.
+        items.sort(key=lambda x: (x["score"] is None, -(x["score"] or 0), -x["verifiable"]))
+        return items
+
+    return {
+        "politicians": ranked(politicians),
+        "parties": ranked(parties),
+        "claims": claims_out,
+        "ratings": ["Korrekt", "Delvist korrekt", "Misvisende", "Forkert", "Ikke verificerbar"],
+    }

--- a/src/vejle_faktatjek/pipeline.py
+++ b/src/vejle_faktatjek/pipeline.py
@@ -45,6 +45,18 @@ def step_transcribe(store: Store, meeting_id: int) -> int:
     return len(segs)
 
 
+def step_identify_speakers(store: Store, meeting_id: int,
+                           threshold: float = 0.5) -> tuple[int, dict[str, str]]:
+    """Tildel politikere til segmenter via stemme-aftryk. Returnerer (antal, mapping)."""
+    from .speakers import apply_label_map
+    from .voiceprints import identify_meeting_speakers
+    m = store.meeting(meeting_id)
+    if not m["audio_path"]:
+        raise RuntimeError("Mødet har ingen lydfil. Kør fetch + transcribe først.")
+    mapping = identify_meeting_speakers(store, meeting_id, Path(m["audio_path"]), threshold)
+    return apply_label_map(store, meeting_id, mapping), mapping
+
+
 def step_extract_claims(store: Store, meeting_id: int) -> int:
     import anthropic
 
@@ -99,7 +111,10 @@ def run_all(store: Store, url: str, date: str, title: str,
     meeting_id = store.create_meeting(date, title, url)
     step_fetch(store, meeting_id, url)
     step_transcribe(store, meeting_id)
-    if label_map:
+    # Foretræk automatisk taler-ID via stemme-aftryk; fald tilbage til en manuel
+    # kortlægning hvis ingen aftryk er enrolleret.
+    n_auto, _ = step_identify_speakers(store, meeting_id)
+    if n_auto == 0 and label_map:
         from .speakers import apply_label_map
         apply_label_map(store, meeting_id, label_map)
     step_extract_claims(store, meeting_id)

--- a/src/vejle_faktatjek/pipeline.py
+++ b/src/vejle_faktatjek/pipeline.py
@@ -1,0 +1,108 @@
+"""Orkestrering: bind trinnene sammen til en kørbar pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from .config import CONFIG
+from .store import Store
+
+
+def load_roster(store: Store, path: Optional[Path] = None) -> int:
+    """Indlæs politiker-roster fra JSON ([{name, party, voiceprint?}, ...])."""
+    path = path or CONFIG.politicians_path
+    if not Path(path).exists():
+        return 0
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    for p in data:
+        store.upsert_politician(p["name"], p["party"], p.get("voiceprint"))
+    return len(data)
+
+
+def step_fetch(store: Store, meeting_id: int, url: str) -> Path:
+    from . import fetch  # tung import (yt-dlp/ffmpeg) — kun ved behov
+    m = store.meeting(meeting_id)
+    wav = fetch.download_audio(url, CONFIG.audio_dir, name=str(m["date"]))
+    store.set_meeting_audio(meeting_id, str(wav))
+    return wav
+
+
+def step_transcribe(store: Store, meeting_id: int) -> int:
+    from . import transcribe  # tung import (whisperx/torch) — kun ved behov
+    m = store.meeting(meeting_id)
+    if not m["audio_path"]:
+        raise RuntimeError("Mødet har ingen lydfil. Kør fetch først.")
+    segs = transcribe.transcribe(
+        Path(m["audio_path"]),
+        model_name=CONFIG.whisper_model,
+        hf_token=CONFIG.hf_token,
+    )
+    segs = transcribe.merge_consecutive(segs)
+    store.replace_segments(meeting_id, segs)
+    store.set_meeting_status(meeting_id, "transcribed")
+    return len(segs)
+
+
+def step_extract_claims(store: Store, meeting_id: int) -> int:
+    import anthropic
+
+    from .claims import extract_claims
+    client = anthropic.Anthropic(api_key=CONFIG.require_api_key())
+
+    rows = []
+    for seg in store.segments(meeting_id):
+        for claim in extract_claims(seg["text"], client=client):
+            rows.append({
+                "segment_id": seg["id"],
+                "politician_id": seg["politician_id"],
+                "text": claim.text,
+                "category": claim.category,
+                "ts": seg["start"],
+            })
+    store.replace_claims(meeting_id, rows)
+    store.set_meeting_status(meeting_id, "claims")
+    return len(rows)
+
+
+def step_factcheck(store: Store, meeting_id: int) -> int:
+    import anthropic
+
+    from .factcheck import factcheck
+    client = anthropic.Anthropic(api_key=CONFIG.require_api_key())
+
+    pending = store.claims_without_verdict(meeting_id)
+    for claim in pending:
+        verdict = factcheck(claim["text"], client=client)
+        store.save_verdict(
+            claim["id"], verdict.rating, verdict.confidence, verdict.explanation,
+            [s.model_dump() for s in verdict.sources],
+        )
+    store.set_meeting_status(meeting_id, "factchecked")
+    return len(pending)
+
+
+def step_build_site(store: Store) -> Path:
+    from .leaderboard import build_leaderboard
+    data = build_leaderboard(store)
+    out = CONFIG.site_data_path
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return out
+
+
+def run_all(store: Store, url: str, date: str, title: str,
+            label_map: Optional[dict[str, str]] = None) -> int:
+    """Kør hele kæden for et nyt møde. Returnerer meeting_id."""
+    load_roster(store)
+    meeting_id = store.create_meeting(date, title, url)
+    step_fetch(store, meeting_id, url)
+    step_transcribe(store, meeting_id)
+    if label_map:
+        from .speakers import apply_label_map
+        apply_label_map(store, meeting_id, label_map)
+    step_extract_claims(store, meeting_id)
+    step_factcheck(store, meeting_id)
+    step_build_site(store)
+    return meeting_id

--- a/src/vejle_faktatjek/seed.py
+++ b/src/vejle_faktatjek/seed.py
@@ -1,0 +1,59 @@
+"""Indlæs sample-data, så leaderboardet kan vises uden at køre ML/Claude.
+
+Læser data/sample/*.json (møder med segmenter, påstande og færdige domme) og
+skriver dem direkte i databasen.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .config import CONFIG
+from .pipeline import load_roster
+from .store import Store
+
+
+def seed_demo(store: Store, sample_dir: Path | None = None) -> dict:
+    sample_dir = sample_dir or CONFIG.sample_dir
+    load_roster(store)
+
+    meetings = json.loads((sample_dir / "meetings.json").read_text(encoding="utf-8"))
+    n_claims = 0
+    n_verdicts = 0
+
+    for m in meetings:
+        meeting_id = store.create_meeting(m["date"], m["title"], m.get("source_url", ""))
+        store.set_meeting_status(meeting_id, "factchecked")
+
+        segs = m.get("segments", [])
+        for s in segs:
+            pol = store.politician_by_name(s["politician"]) if s.get("politician") else None
+            s["politician_id"] = pol["id"] if pol else None
+        seg_ids = store.replace_segments(meeting_id, segs)
+
+        claim_rows = []
+        for c in m.get("claims", []):
+            pol = store.politician_by_name(c["politician"]) if c.get("politician") else None
+            claim_rows.append({
+                "segment_id": None,
+                "politician_id": pol["id"] if pol else None,
+                "text": c["text"],
+                "category": c.get("category"),
+                "ts": c.get("ts"),
+                "_verdict": c.get("verdict"),
+            })
+        claim_ids = store.replace_claims(meeting_id, claim_rows)
+        n_claims += len(claim_ids)
+
+        for claim_id, c in zip(claim_ids, claim_rows):
+            v = c.get("_verdict")
+            if not v:
+                continue
+            store.save_verdict(
+                claim_id, v["rating"], v.get("confidence", 0.7),
+                v.get("explanation", ""), v.get("sources", []),
+            )
+            n_verdicts += 1
+
+    return {"meetings": len(meetings), "claims": n_claims, "verdicts": n_verdicts}

--- a/src/vejle_faktatjek/speakers.py
+++ b/src/vejle_faktatjek/speakers.py
@@ -1,0 +1,41 @@
+"""Match diarization-labels ("Speaker 1") til navngivne politikere.
+
+Stemme-baseret matching (embeddings pr. byrådsmedlem) er det rigtige langsigtede
+svar, men kræver indtalte profiler. Indtil da tilbyder dette modul en simpel,
+manuel kortlægning: en dict fra speaker-label til politiker-navn, fx udledt af
+referatets talerækkefølge og derefter kvalitetssikret i hånden.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .store import Store
+
+
+def apply_label_map(store: Store, meeting_id: int, label_to_name: dict[str, str]) -> int:
+    """Tildel politiker-id til segmenter ud fra en {label: navn}-kortlægning.
+
+    Navne der ikke findes i roster oprettes ikke automatisk — de skal ligge i
+    ``data/politicians.json``. Returnerer antal opdaterede segmenter.
+    """
+    updated = 0
+    for seg in store.segments(meeting_id):
+        label = seg["speaker_label"]
+        if not label or label not in label_to_name:
+            continue
+        pol = store.politician_by_name(label_to_name[label])
+        if pol is None:
+            continue
+        store.set_segment_politician(seg["id"], pol["id"])
+        updated += 1
+    return updated
+
+
+def speaker_label_summary(store: Store, meeting_id: int) -> dict[str, int]:
+    """Tæl segmenter pr. speaker-label — hjælper med at lave kortlægningen."""
+    counts: dict[str, int] = {}
+    for seg in store.segments(meeting_id):
+        label = seg["speaker_label"] or "Ukendt"
+        counts[label] = counts.get(label, 0) + 1
+    return counts

--- a/src/vejle_faktatjek/store.py
+++ b/src/vejle_faktatjek/store.py
@@ -105,6 +105,15 @@ class Store:
     def politician_by_name(self, name: str) -> Optional[sqlite3.Row]:
         return self.conn.execute("SELECT * FROM politicians WHERE name=?", (name,)).fetchone()
 
+    def set_voiceprint(self, politician_id: int, voiceprint_json: str) -> None:
+        with self._tx() as c:
+            c.execute("UPDATE politicians SET voiceprint=? WHERE id=?", (voiceprint_json, politician_id))
+
+    def politicians_with_voiceprints(self) -> list[sqlite3.Row]:
+        return self.conn.execute(
+            "SELECT * FROM politicians WHERE voiceprint IS NOT NULL AND voiceprint != ''"
+        ).fetchall()
+
     # ---- meetings ----
     def create_meeting(self, date: str, title: str, source_url: str = "") -> int:
         with self._tx() as c:

--- a/src/vejle_faktatjek/store.py
+++ b/src/vejle_faktatjek/store.py
@@ -1,0 +1,210 @@
+"""SQLite-lager og datamodel for pipelinen.
+
+Tabeller:
+  politicians (id, name, party, voiceprint)
+  meetings    (id, date, title, source_url, audio_path, status)
+  segments    (id, meeting_id, idx, speaker_label, politician_id, start, end, text)
+  claims      (id, meeting_id, segment_id, politician_id, text, category, ts)
+  verdicts    (id, claim_id, rating, confidence, explanation, sources, created_at)
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS politicians (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL UNIQUE,
+    party       TEXT NOT NULL,
+    voiceprint  TEXT
+);
+CREATE TABLE IF NOT EXISTS meetings (
+    id          INTEGER PRIMARY KEY,
+    date        TEXT NOT NULL,
+    title       TEXT NOT NULL,
+    source_url  TEXT,
+    audio_path  TEXT,
+    status      TEXT NOT NULL DEFAULT 'new'
+);
+CREATE TABLE IF NOT EXISTS segments (
+    id            INTEGER PRIMARY KEY,
+    meeting_id    INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+    idx           INTEGER NOT NULL,
+    speaker_label TEXT,
+    politician_id INTEGER REFERENCES politicians(id),
+    start         REAL,
+    "end"         REAL,
+    text          TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS claims (
+    id            INTEGER PRIMARY KEY,
+    meeting_id    INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+    segment_id    INTEGER REFERENCES segments(id),
+    politician_id INTEGER REFERENCES politicians(id),
+    text          TEXT NOT NULL,
+    category      TEXT,
+    ts            REAL
+);
+CREATE TABLE IF NOT EXISTS verdicts (
+    id          INTEGER PRIMARY KEY,
+    claim_id    INTEGER NOT NULL UNIQUE REFERENCES claims(id) ON DELETE CASCADE,
+    rating      TEXT NOT NULL,
+    confidence  REAL,
+    explanation TEXT,
+    sources     TEXT,
+    created_at  TEXT DEFAULT (datetime('now'))
+);
+"""
+
+# Verdict-vurderinger der tæller som "verificerbare" i scoren.
+VERIFIABLE_RATINGS = {"Korrekt", "Delvist korrekt", "Misvisende", "Forkert"}
+# Vægt pr. dom: 1.0 = fuldt pålidelig, 0.0 = upålidelig.
+RATING_WEIGHT = {
+    "Korrekt": 1.0,
+    "Delvist korrekt": 0.5,
+    "Misvisende": 0.25,
+    "Forkert": 0.0,
+}
+
+
+class Store:
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON")
+        self.conn.executescript(SCHEMA)
+
+    @contextmanager
+    def _tx(self) -> Iterator[sqlite3.Connection]:
+        try:
+            yield self.conn
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
+
+    # ---- politicians ----
+    def upsert_politician(self, name: str, party: str, voiceprint: Optional[str] = None) -> int:
+        with self._tx() as c:
+            c.execute(
+                """INSERT INTO politicians (name, party, voiceprint) VALUES (?, ?, ?)
+                   ON CONFLICT(name) DO UPDATE SET party=excluded.party,
+                       voiceprint=COALESCE(excluded.voiceprint, politicians.voiceprint)""",
+                (name, party, voiceprint),
+            )
+        row = self.conn.execute("SELECT id FROM politicians WHERE name=?", (name,)).fetchone()
+        return row["id"]
+
+    def politician_by_name(self, name: str) -> Optional[sqlite3.Row]:
+        return self.conn.execute("SELECT * FROM politicians WHERE name=?", (name,)).fetchone()
+
+    # ---- meetings ----
+    def create_meeting(self, date: str, title: str, source_url: str = "") -> int:
+        with self._tx() as c:
+            cur = c.execute(
+                "INSERT INTO meetings (date, title, source_url) VALUES (?, ?, ?)",
+                (date, title, source_url),
+            )
+        return cur.lastrowid
+
+    def set_meeting_audio(self, meeting_id: int, audio_path: str) -> None:
+        with self._tx() as c:
+            c.execute("UPDATE meetings SET audio_path=? WHERE id=?", (audio_path, meeting_id))
+
+    def set_meeting_status(self, meeting_id: int, status: str) -> None:
+        with self._tx() as c:
+            c.execute("UPDATE meetings SET status=? WHERE id=?", (status, meeting_id))
+
+    def meeting(self, meeting_id: int) -> Optional[sqlite3.Row]:
+        return self.conn.execute("SELECT * FROM meetings WHERE id=?", (meeting_id,)).fetchone()
+
+    # ---- segments ----
+    def replace_segments(self, meeting_id: int, segments: Iterable[dict]) -> list[int]:
+        ids: list[int] = []
+        with self._tx() as c:
+            c.execute("DELETE FROM segments WHERE meeting_id=?", (meeting_id,))
+            for i, s in enumerate(segments):
+                cur = c.execute(
+                    """INSERT INTO segments
+                       (meeting_id, idx, speaker_label, politician_id, start, "end", text)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (meeting_id, i, s.get("speaker"), s.get("politician_id"),
+                     s.get("start"), s.get("end"), s["text"]),
+                )
+                ids.append(cur.lastrowid)
+        return ids
+
+    def segments(self, meeting_id: int) -> list[sqlite3.Row]:
+        return self.conn.execute(
+            "SELECT * FROM segments WHERE meeting_id=? ORDER BY idx", (meeting_id,)
+        ).fetchall()
+
+    def set_segment_politician(self, segment_id: int, politician_id: Optional[int]) -> None:
+        with self._tx() as c:
+            c.execute("UPDATE segments SET politician_id=? WHERE id=?", (politician_id, segment_id))
+
+    # ---- claims ----
+    def replace_claims(self, meeting_id: int, claims: Iterable[dict]) -> list[int]:
+        ids: list[int] = []
+        with self._tx() as c:
+            c.execute("DELETE FROM claims WHERE meeting_id=?", (meeting_id,))
+            for cl in claims:
+                cur = c.execute(
+                    """INSERT INTO claims
+                       (meeting_id, segment_id, politician_id, text, category, ts)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (meeting_id, cl.get("segment_id"), cl.get("politician_id"),
+                     cl["text"], cl.get("category"), cl.get("ts")),
+                )
+                ids.append(cur.lastrowid)
+        return ids
+
+    def claims(self, meeting_id: Optional[int] = None) -> list[sqlite3.Row]:
+        if meeting_id is None:
+            return self.conn.execute("SELECT * FROM claims").fetchall()
+        return self.conn.execute(
+            "SELECT * FROM claims WHERE meeting_id=?", (meeting_id,)
+        ).fetchall()
+
+    def claims_without_verdict(self, meeting_id: int) -> list[sqlite3.Row]:
+        return self.conn.execute(
+            """SELECT c.* FROM claims c
+               LEFT JOIN verdicts v ON v.claim_id = c.id
+               WHERE c.meeting_id=? AND v.id IS NULL""",
+            (meeting_id,),
+        ).fetchall()
+
+    # ---- verdicts ----
+    def save_verdict(self, claim_id: int, rating: str, confidence: float,
+                     explanation: str, sources: list[dict]) -> None:
+        with self._tx() as c:
+            c.execute(
+                """INSERT INTO verdicts (claim_id, rating, confidence, explanation, sources)
+                   VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT(claim_id) DO UPDATE SET rating=excluded.rating,
+                       confidence=excluded.confidence, explanation=excluded.explanation,
+                       sources=excluded.sources, created_at=datetime('now')""",
+                (claim_id, rating, confidence, explanation, json.dumps(sources, ensure_ascii=False)),
+            )
+
+    def verdict_rows(self) -> list[sqlite3.Row]:
+        """Alle domme joinet med påstand + politiker, til aggregering."""
+        return self.conn.execute(
+            """SELECT v.*, c.text AS claim_text, c.category, c.meeting_id,
+                      p.id AS politician_id, p.name AS politician, p.party,
+                      m.date, m.title
+               FROM verdicts v
+               JOIN claims c       ON c.id = v.claim_id
+               LEFT JOIN politicians p ON p.id = c.politician_id
+               LEFT JOIN meetings m    ON m.id = c.meeting_id"""
+        ).fetchall()
+
+    def close(self) -> None:
+        self.conn.close()

--- a/src/vejle_faktatjek/transcribe.py
+++ b/src/vejle_faktatjek/transcribe.py
@@ -1,0 +1,78 @@
+"""Dansk transskription med speaker diarization.
+
+Producerer en liste af segmenter: ``{"speaker", "start", "end", "text"}``.
+
+Implementeringen bruger WhisperX (ord-præcise tidsstempler + pyannote
+diarization). For bedst dansk kvalitet: peg ``VF_WHISPER_MODEL`` på en
+dansk-tunet model (fx CoRal/Alvenir Whisper-vægte) i stedet for ``large-v3``.
+
+Afhængighederne er tunge og valgfrie — importen sker først ved kald, så resten
+af pipelinen kan køre uden dem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def transcribe(audio_path: Path, model_name: str = "large-v3",
+               hf_token: str = "", device: str = "auto",
+               language: str = "da") -> list[dict]:
+    """Transskribér ``audio_path`` med taler-labels.
+
+    Returnerer segmenter med felterne ``speaker``, ``start``, ``end``, ``text``.
+    Diarization springes over (alle ``speaker=None``), hvis ``hf_token`` mangler.
+    """
+    try:
+        import torch  # type: ignore
+        import whisperx  # type: ignore
+    except ImportError as e:  # pragma: no cover - afhænger af valgfri pakker
+        raise RuntimeError(
+            "whisperx/torch er ikke installeret. Afkommentér dem i requirements.txt "
+            "og kør `pip install -r requirements.txt`."
+        ) from e
+
+    if device == "auto":
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    compute_type = "float16" if device == "cuda" else "int8"
+
+    audio = whisperx.load_audio(str(audio_path))
+
+    model = whisperx.load_model(model_name, device, compute_type=compute_type, language=language)
+    result = model.transcribe(audio, language=language)
+
+    # Ord-præcise tidsstempler (forbedrer både diarization-match og citat-links).
+    align_model, metadata = whisperx.load_align_model(language_code=language, device=device)
+    result = whisperx.align(result["segments"], align_model, metadata, audio, device)
+
+    if hf_token:
+        diarize = whisperx.DiarizationPipeline(use_auth_token=hf_token, device=device)
+        diarize_segments = diarize(audio)
+        result = whisperx.assign_word_speakers(diarize_segments, result)
+
+    segments: list[dict] = []
+    for seg in result["segments"]:
+        text = (seg.get("text") or "").strip()
+        if not text:
+            continue
+        segments.append({
+            "speaker": seg.get("speaker"),
+            "start": seg.get("start"),
+            "end": seg.get("end"),
+            "text": text,
+        })
+    return segments
+
+
+def merge_consecutive(segments: list[dict]) -> list[dict]:
+    """Slå tilstødende segmenter fra samme taler sammen til hele taleture."""
+    merged: list[dict] = []
+    for s in segments:
+        if merged and merged[-1].get("speaker") == s.get("speaker"):
+            prev = merged[-1]
+            prev["text"] = f"{prev['text']} {s['text']}".strip()
+            prev["end"] = s.get("end", prev.get("end"))
+        else:
+            merged.append(dict(s))
+    return merged

--- a/src/vejle_faktatjek/voiceprints.py
+++ b/src/vejle_faktatjek/voiceprints.py
@@ -1,0 +1,126 @@
+"""Stemme-aftryk til automatisk taler-identifikation.
+
+Idé: enrollér hver politiker én gang fra et stykke lyd hvor man ved hvem der
+taler → gem et stemme-embedding (ECAPA-TDNN) på politikeren. Ved hvert nyt møde
+beregnes et embedding pr. diarization-klynge ("SPEAKER_00", …) og matches mod de
+gemte aftryk via cosine-lighed. Klynger over en tærskel tildeles den nærmeste
+politiker; resten forbliver ukendte (og kan rettes manuelt).
+
+Embedding-modellen er en tung, valgfri afhængighed — importeres først ved kald.
+Standard er SpeechBrain ECAPA-TDNN (``speechbrain/spkrec-ecapa-voxceleb``), som
+ikke kræver gated Hugging Face-adgang.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from .store import Store
+
+# Empirisk cosine-tærskel for "samme taler" med L2-normaliserede ECAPA-embeddings.
+# Juster på egne data: højere = færre fejl-match, flere ukendte.
+DEFAULT_THRESHOLD = 0.5
+
+_MODEL = None
+
+
+def _load_model():
+    global _MODEL
+    if _MODEL is None:
+        try:
+            from speechbrain.inference.speaker import EncoderClassifier  # type: ignore
+        except ImportError as e:  # pragma: no cover - valgfri pakke
+            raise RuntimeError(
+                "speechbrain/torchaudio er ikke installeret. Afkommentér dem i "
+                "requirements.txt og kør `pip install -r requirements.txt`."
+            ) from e
+        _MODEL = EncoderClassifier.from_hparams(
+            source="speechbrain/spkrec-ecapa-voxceleb",
+            run_opts={"device": "cpu"},
+        )
+    return _MODEL
+
+
+def _embed_spans(audio_path: Path, spans: Optional[list[tuple[float, float]]]):
+    """Beregn ét L2-normaliseret embedding ud fra de(t) givne lyd-udsnit.
+
+    ``spans`` er en liste af (start, slut) i sekunder; None = hele filen.
+    """
+    import numpy as np  # type: ignore
+    import torchaudio  # type: ignore
+
+    model = _load_model()
+    wav, sr = torchaudio.load(str(audio_path))
+    if wav.shape[0] > 1:  # downmix til mono
+        wav = wav.mean(dim=0, keepdim=True)
+    if sr != 16000:
+        wav = torchaudio.functional.resample(wav, sr, 16000)
+        sr = 16000
+
+    if not spans:
+        chunks = [wav]
+    else:
+        chunks = []
+        for start, end in spans:
+            a, b = int(start * sr), int(end * sr)
+            seg = wav[:, a:b]
+            if seg.shape[1] > sr * 0.3:  # spring meget korte udsnit over
+                chunks.append(seg)
+        if not chunks:
+            chunks = [wav]
+
+    embs = []
+    for ch in chunks:
+        e = model.encode_batch(ch).squeeze().detach().cpu().numpy()
+        embs.append(e)
+    emb = np.mean(embs, axis=0)
+    return emb / (np.linalg.norm(emb) + 1e-9)
+
+
+def enroll_politician(store: Store, name: str, audio_path: Path,
+                      spans: Optional[list[tuple[float, float]]] = None) -> int:
+    """Beregn og gem et stemme-aftryk for en politiker. Returnerer dimensionen."""
+    pol = store.politician_by_name(name)
+    if pol is None:
+        raise ValueError(f"Ukendt politiker: {name!r}. Tilføj til data/politicians.json først.")
+    emb = _embed_spans(Path(audio_path), spans)
+    store.set_voiceprint(pol["id"], json.dumps(emb.tolist()))
+    return int(emb.shape[0])
+
+
+def load_voiceprints(store: Store) -> dict[str, list]:
+    return {p["name"]: json.loads(p["voiceprint"]) for p in store.politicians_with_voiceprints()}
+
+
+def identify_meeting_speakers(store: Store, meeting_id: int, audio_path: Path,
+                              threshold: float = DEFAULT_THRESHOLD) -> dict[str, str]:
+    """Match diarization-labels til politikere. Returnerer {label: navn}.
+
+    Kun klynger med en cosine-lighed >= ``threshold`` tildeles.
+    """
+    import numpy as np  # type: ignore
+
+    prints = load_voiceprints(store)
+    if not prints:
+        return {}
+
+    label_spans: dict[str, list[tuple[float, float]]] = {}
+    for seg in store.segments(meeting_id):
+        label = seg["speaker_label"]
+        if not label or seg["start"] is None or seg["end"] is None:
+            continue
+        label_spans.setdefault(label, []).append((seg["start"], seg["end"]))
+
+    names = list(prints)
+    matrix = np.vstack([np.array(prints[n]) for n in names])  # (P, D), allerede normaliseret
+
+    mapping: dict[str, str] = {}
+    for label, spans in label_spans.items():
+        emb = _embed_spans(Path(audio_path), spans)
+        sims = matrix @ emb  # cosine, da begge er normaliserede
+        best = int(np.argmax(sims))
+        if float(sims[best]) >= threshold:
+            mapping[label] = names[best]
+    return mapping

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,88 @@
+const RATING_COLOR = {
+  "Korrekt": "var(--korrekt)",
+  "Delvist korrekt": "var(--delvist)",
+  "Misvisende": "var(--misvisende)",
+  "Forkert": "var(--forkert)",
+  "Ikke verificerbar": "var(--ukendt)",
+};
+
+let DATA = null;
+
+function scoreColor(score) {
+  if (score === null || score === undefined) return "var(--ukendt)";
+  if (score >= 75) return "var(--korrekt)";
+  if (score >= 50) return "var(--delvist)";
+  if (score >= 25) return "var(--misvisende)";
+  return "var(--forkert)";
+}
+
+function breakdownBar(breakdown) {
+  const order = ["Korrekt", "Delvist korrekt", "Misvisende", "Forkert", "Ikke verificerbar"];
+  const total = order.reduce((s, r) => s + (breakdown[r] || 0), 0) || 1;
+  const segs = order
+    .filter((r) => breakdown[r])
+    .map((r) => `<span style="width:${(100 * breakdown[r]) / total}%;background:${RATING_COLOR[r]}" title="${r}: ${breakdown[r]}"></span>`)
+    .join("");
+  return `<div class="bar">${segs}</div>`;
+}
+
+function renderRanking(list) {
+  if (!list.length) return `<p class="empty">Ingen data endnu. Kør pipelinen eller <code>seed-demo</code>.</p>`;
+  return list.map((item, i) => {
+    const score = item.score === null ? "–" : item.score;
+    const suffix = item.score === null ? "" : "%";
+    return `
+      <div class="row">
+        <div class="rank">${i + 1}</div>
+        <div class="who">
+          <div class="name">${item.name}</div>
+          ${item.party && item.party !== item.name ? `<div class="party">${item.party}</div>` : ""}
+        </div>
+        <div class="score">
+          <div class="val" style="color:${scoreColor(item.score)}">${score}${suffix}</div>
+          <div class="count">${item.verifiable} verificerbare / ${item.total} i alt</div>
+        </div>
+        ${breakdownBar(item.breakdown)}
+      </div>`;
+  }).join("");
+}
+
+function renderClaims(claims) {
+  if (!claims.length) return `<p class="empty">Ingen påstande endnu.</p>`;
+  return claims.map((c) => {
+    const color = RATING_COLOR[c.rating] || "var(--ukendt)";
+    const sources = (c.sources || [])
+      .map((s) => `<a href="${s.url}" target="_blank" rel="noopener">${s.title || s.url}</a>`)
+      .join("");
+    return `
+      <div class="claim" style="border-left-color:${color}">
+        <div class="head">
+          <span class="meta">${c.politician} (${c.party}) · ${c.meeting?.date || ""}</span>
+          <span class="badge" style="background:${color};color:#0f1419">${c.rating}</span>
+        </div>
+        <div class="text">${c.claim}</div>
+        <div class="expl">${c.explanation || ""}</div>
+        <div class="sources">${sources}</div>
+      </div>`;
+  }).join("");
+}
+
+function show(view) {
+  const board = document.getElementById("board");
+  if (!DATA) { board.innerHTML = `<p class="empty">Indlæser …</p>`; return; }
+  if (view === "claims") board.innerHTML = renderClaims(DATA.claims);
+  else board.innerHTML = renderRanking(DATA[view]);
+  document.querySelectorAll(".tab").forEach((t) => t.classList.toggle("active", t.dataset.view === view));
+}
+
+document.querySelectorAll(".tab").forEach((tab) =>
+  tab.addEventListener("click", () => show(tab.dataset.view))
+);
+
+fetch("leaderboard.json")
+  .then((r) => r.json())
+  .then((data) => { DATA = data; show("politicians"); })
+  .catch(() => {
+    document.getElementById("board").innerHTML =
+      `<p class="empty">Kunne ikke indlæse <code>leaderboard.json</code>. Kør <code>build-site</code> først.</p>`;
+  });

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Vejle Faktatjek — Byrådets pålidelighed</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Vejle Faktatjek</h1>
+    <p class="tagline">Faktatjek af påstande fra Vejle Byråds møder. Pålidelighedsscoren bygger kun på efterprøvbare påstande — antallet vises altid ved siden af.</p>
+  </header>
+
+  <main>
+    <nav class="tabs">
+      <button class="tab active" data-view="politicians">Politikere</button>
+      <button class="tab" data-view="parties">Partier</button>
+      <button class="tab" data-view="claims">Alle påstande</button>
+    </nav>
+
+    <section id="board"></section>
+  </main>
+
+  <footer>
+    <p>Datagrundlag: offentlige lydoptagelser fra <a href="https://www.vejle.dk/politik/politik-og-byraad/moeder-i-byraad-og-udvalg/lydoptagelser-fra-byraadsmoeder/">vejle.dk</a>.
+    Domme er automatisk genereret og bør kvalitetssikres af et menneske før de tillægges vægt.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/leaderboard.json
+++ b/web/leaderboard.json
@@ -1,0 +1,226 @@
+{
+  "politicians": [
+    {
+      "name": "Morten Kristensen",
+      "party": "SF",
+      "score": 100.0,
+      "verifiable": 1,
+      "total": 1,
+      "breakdown": {
+        "Korrekt": 1
+      }
+    },
+    {
+      "name": "Jens Ejner Christensen",
+      "party": "Venstre",
+      "score": 75.0,
+      "verifiable": 2,
+      "total": 2,
+      "breakdown": {
+        "Korrekt": 1,
+        "Delvist korrekt": 1
+      }
+    },
+    {
+      "name": "Søren Peschardt",
+      "party": "Socialdemokratiet",
+      "score": 25.0,
+      "verifiable": 1,
+      "total": 1,
+      "breakdown": {
+        "Misvisende": 1
+      }
+    },
+    {
+      "name": "Dan Arnløv Jørgensen",
+      "party": "Det Konservative Folkeparti",
+      "score": 0.0,
+      "verifiable": 1,
+      "total": 1,
+      "breakdown": {
+        "Forkert": 1
+      }
+    },
+    {
+      "name": "Torben Elsig-Pedersen",
+      "party": "Radikale Venstre",
+      "score": null,
+      "verifiable": 0,
+      "total": 1,
+      "breakdown": {
+        "Ikke verificerbar": 1
+      }
+    }
+  ],
+  "parties": [
+    {
+      "name": "SF",
+      "party": "SF",
+      "score": 100.0,
+      "verifiable": 1,
+      "total": 1,
+      "breakdown": {
+        "Korrekt": 1
+      }
+    },
+    {
+      "name": "Venstre",
+      "party": "Venstre",
+      "score": 75.0,
+      "verifiable": 2,
+      "total": 2,
+      "breakdown": {
+        "Korrekt": 1,
+        "Delvist korrekt": 1
+      }
+    },
+    {
+      "name": "Socialdemokratiet",
+      "party": "Socialdemokratiet",
+      "score": 25.0,
+      "verifiable": 1,
+      "total": 1,
+      "breakdown": {
+        "Misvisende": 1
+      }
+    },
+    {
+      "name": "Det Konservative Folkeparti",
+      "party": "Det Konservative Folkeparti",
+      "score": 0.0,
+      "verifiable": 1,
+      "total": 1,
+      "breakdown": {
+        "Forkert": 1
+      }
+    },
+    {
+      "name": "Radikale Venstre",
+      "party": "Radikale Venstre",
+      "score": null,
+      "verifiable": 0,
+      "total": 1,
+      "breakdown": {
+        "Ikke verificerbar": 1
+      }
+    }
+  ],
+  "claims": [
+    {
+      "claim": "Vejle Kommune har over 120.000 indbyggere.",
+      "category": "andet",
+      "politician": "Jens Ejner Christensen",
+      "party": "Venstre",
+      "rating": "Korrekt",
+      "confidence": 0.92,
+      "explanation": "Danmarks Statistik opgør Vejle Kommunes folketal til over 120.000. Påstanden stemmer med de officielle tal.",
+      "sources": [
+        {
+          "title": "Danmarks Statistik — Folketal",
+          "url": "https://www.statistikbanken.dk/folk1a"
+        }
+      ],
+      "meeting": {
+        "date": "2026-03-25",
+        "title": "Byrådsmøde marts 2026 (sample-data)"
+      }
+    },
+    {
+      "claim": "Vejle er den hurtigst voksende kommune i Trekantområdet.",
+      "category": "andet",
+      "politician": "Jens Ejner Christensen",
+      "party": "Venstre",
+      "rating": "Delvist korrekt",
+      "confidence": 0.6,
+      "explanation": "Vejle er blandt de hurtigst voksende kommuner i området, men den præcise placering varierer fra år til år og afhænger af opgørelsesmetode.",
+      "sources": [
+        {
+          "title": "Danmarks Statistik — Befolkningsfremskrivning",
+          "url": "https://www.dst.dk/da/Statistik/emner/befolkning-og-valg"
+        }
+      ],
+      "meeting": {
+        "date": "2026-03-25",
+        "title": "Byrådsmøde marts 2026 (sample-data)"
+      }
+    },
+    {
+      "claim": "Kommunens kassebeholdning er faldet med næsten en halv milliard kroner på to år.",
+      "category": "økonomi",
+      "politician": "Søren Peschardt",
+      "party": "Socialdemokratiet",
+      "rating": "Misvisende",
+      "confidence": 0.55,
+      "explanation": "Kassebeholdningen er faldet, men ikke i den størrelsesorden ifølge kommunens regnskaber; tallet mangler kontekst om planlagte anlægsinvesteringer.",
+      "sources": [
+        {
+          "title": "Vejle Kommune — Årsregnskab",
+          "url": "https://www.vejle.dk/om-kommunen/oekonomi/"
+        }
+      ],
+      "meeting": {
+        "date": "2026-03-25",
+        "title": "Byrådsmøde marts 2026 (sample-data)"
+      }
+    },
+    {
+      "claim": "Ledigheden i Vejle Kommune er lavere end landsgennemsnittet.",
+      "category": "beskæftigelse",
+      "politician": "Morten Kristensen",
+      "party": "SF",
+      "rating": "Korrekt",
+      "confidence": 0.8,
+      "explanation": "Officielle ledighedstal viser en bruttoledighed i Vejle under landsgennemsnittet i den seneste opgørelse.",
+      "sources": [
+        {
+          "title": "Jobindsats / Danmarks Statistik",
+          "url": "https://www.jobindsats.dk/"
+        }
+      ],
+      "meeting": {
+        "date": "2026-03-25",
+        "title": "Byrådsmøde marts 2026 (sample-data)"
+      }
+    },
+    {
+      "claim": "Kommunen plantede én million træer sidste år.",
+      "category": "klima",
+      "politician": "Torben Elsig-Pedersen",
+      "party": "Radikale Venstre",
+      "rating": "Ikke verificerbar",
+      "confidence": 0.4,
+      "explanation": "Der findes ingen offentligt tilgængelig opgørelse der be- eller afkræfter det præcise antal plantede træer.",
+      "sources": [],
+      "meeting": {
+        "date": "2026-03-25",
+        "title": "Byrådsmøde marts 2026 (sample-data)"
+      }
+    },
+    {
+      "claim": "Vejle Kommune har ikke hævet dækningsafgiften de seneste fem år.",
+      "category": "økonomi",
+      "politician": "Dan Arnløv Jørgensen",
+      "party": "Det Konservative Folkeparti",
+      "rating": "Forkert",
+      "confidence": 0.7,
+      "explanation": "Budgetmaterialet viser en justering af dækningsafgiften inden for perioden, hvilket modsiger påstanden.",
+      "sources": [
+        {
+          "title": "Vejle Kommune — Budget",
+          "url": "https://www.vejle.dk/om-kommunen/oekonomi/"
+        }
+      ],
+      "meeting": {
+        "date": "2026-03-25",
+        "title": "Byrådsmøde marts 2026 (sample-data)"
+      }
+    }
+  ],
+  "ratings": [
+    "Korrekt",
+    "Delvist korrekt",
+    "Misvisende",
+    "Forkert",
+    "Ikke verificerbar"
+  ]
+}

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,73 @@
+:root {
+  --bg: #0f1419;
+  --card: #1a2129;
+  --card-2: #222b35;
+  --text: #e6edf3;
+  --muted: #8b98a5;
+  --line: #2d3742;
+  --korrekt: #3fb950;
+  --delvist: #9ece6a;
+  --misvisende: #d29922;
+  --forkert: #f85149;
+  --ukendt: #6e7681;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+header {
+  padding: 2.5rem 1.5rem 1.5rem;
+  max-width: 880px;
+  margin: 0 auto;
+}
+header h1 { margin: 0 0 .5rem; font-size: 2rem; }
+.tagline { color: var(--muted); margin: 0; max-width: 60ch; }
+
+main { max-width: 880px; margin: 0 auto; padding: 0 1.5rem 3rem; }
+
+.tabs { display: flex; gap: .5rem; margin: 1.5rem 0; border-bottom: 1px solid var(--line); }
+.tab {
+  background: none; border: none; color: var(--muted);
+  padding: .75rem 1rem; cursor: pointer; font-size: 1rem;
+  border-bottom: 2px solid transparent;
+}
+.tab.active { color: var(--text); border-bottom-color: var(--korrekt); }
+
+.row {
+  display: grid; grid-template-columns: 2rem 1fr auto; gap: 1rem;
+  align-items: center; padding: 1rem; background: var(--card);
+  border-radius: 10px; margin-bottom: .6rem;
+}
+.rank { color: var(--muted); font-variant-numeric: tabular-nums; text-align: center; }
+.who .name { font-weight: 600; }
+.who .party { color: var(--muted); font-size: .85rem; }
+.score { text-align: right; }
+.score .val { font-size: 1.5rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.score .count { color: var(--muted); font-size: .8rem; }
+
+.bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden; margin-top: .5rem; grid-column: 1 / -1; }
+.bar span { display: block; }
+
+.claim {
+  background: var(--card); border-radius: 10px; padding: 1rem 1.2rem; margin-bottom: .8rem;
+  border-left: 4px solid var(--ukendt);
+}
+.claim .head { display: flex; justify-content: space-between; gap: 1rem; align-items: baseline; flex-wrap: wrap; }
+.claim .text { font-weight: 600; margin: .2rem 0 .4rem; }
+.claim .meta { color: var(--muted); font-size: .85rem; }
+.claim .expl { color: var(--text); font-size: .92rem; margin: .5rem 0; }
+.badge { font-size: .8rem; font-weight: 700; padding: .15rem .5rem; border-radius: 6px; white-space: nowrap; }
+.sources { font-size: .82rem; }
+.sources a { color: #58a6ff; display: inline-block; margin-right: .8rem; }
+
+.empty { color: var(--muted); padding: 2rem; text-align: center; }
+
+footer { max-width: 880px; margin: 0 auto; padding: 2rem 1.5rem; color: var(--muted); font-size: .82rem; border-top: 1px solid var(--line); }
+footer a { color: #58a6ff; }


### PR DESCRIPTION
Tilføjer en komplet, modulær pipeline der henter lydoptagelser fra Vejle Byråds **afholdte** møder (Vejle sender ikke live-TV — kun lydoptagelser publiceres på vejle.dk), transskriberer dem, udtrækker efterprøvbare påstande, faktatjekker dem evidensbaseret med Claude, og bygger et leaderboard over politikernes og partiernes pålidelighed.

## Pipeline

```
vejle.dk lyd-URL → fetch → transcribe (ASR + diarization) → taler-ID
   → claims (Claude, struktureret output) → factcheck (Claude + web_search)
   → SQLite → leaderboard.json → statisk side
```

## Moduler

| Modul | Ansvar |
|-------|--------|
| `fetch.py` | Hent lyd via yt-dlp → 16 kHz WAV |
| `transcribe.py` | Dansk ASR + speaker diarization (WhisperX) |
| `voiceprints.py` | Automatisk taler-ID via stemme-aftryk (ECAPA-TDNN, cosine-match) |
| `speakers.py` | Manuel label→politiker-kortlægning som fallback |
| `claims.py` | Udtræk efterprøvbare påstande (struktureret output) |
| `factcheck.py` | To-trins evidensbaseret dom (web_search → struktureret dom) |
| `store.py` | SQLite-lager + datamodel |
| `leaderboard.py` | Aggregér domme til pålidelighedsscorer |
| `pipeline.py` / `cli.py` | Orkestrering + kommandolinje |

## Vigtige designvalg

- **Faktatjek bygger på fremfundet evidens, ikke modellens hukommelse** — `web_search` finder kilder, en separat dom vurderer kun ud fra dem (Korrekt / Delvist korrekt / Misvisende / Forkert / Ikke verificerbar).
- **Scoren bygger kun på verificerbare påstande**, og antal vises altid ved siden af scoren, så en der siger lidt ikke fremstår kunstigt pålidelig.
- **Tunge afhængigheder (Whisper, SpeechBrain) er valgfrie** og importeres først ved kald — resten af pipelinen og leaderboardet kører uden dem.

## Afprøvet

Demo-flowet kører end-to-end uden GPU/API-nøgle via medfølgende sample-data:

```bash
python -m vejle_faktatjek.cli seed-demo
python -m vejle_faktatjek.cli build-site
python -m http.server -d web 8000
```

Alle moduler importerer rent; demo-leaderboardet rendrer med vurderings-breakdown og kildelinks pr. påstand.

## Status / opfølgning

- Faktatjek-domme bør kvalitetssikres af et menneske før de tillægges vægt.
- Cosine-tærsklen for stemme-match (0.5) bør kalibreres på rigtige Vejle-optagelser.
- `data/politicians.json` indeholder en seed der skal verificeres mod byrådets faktiske sammensætning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNpivPfVhyb9gtK4AJN4DY